### PR TITLE
Fix cpp backend

### DIFF
--- a/backends/cpp/build/CMakeLists.txt
+++ b/backends/cpp/build/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wfatal-errors -Wextra -g -O3 -pthread")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../../../bin)
 
 # Bulk examples that work for any backend
 

--- a/backends/cpp/coarray.hpp
+++ b/backends/cpp/coarray.hpp
@@ -43,7 +43,7 @@ class coarray {
                 // Compute total size
                 int total_size = 0;
                 for (int i = 0; i < world_.active_processors(); i++)
-                    total_size += x(i);
+                    total_size += x.get_ref(i);
 
                 all_values_ = new T[total_size];
                 other_values_ = new T*[world_.active_processors()];
@@ -52,7 +52,7 @@ class coarray {
                 int total = 0;
                 for (int i = 0; i < world_.active_processors(); i++) {
                     other_values_[i] = &all_values_[total];
-                    total += x(i);
+                    total += x.get_ref(i);
                 }
 
                 // Give the buffers to other cores
@@ -61,8 +61,8 @@ class coarray {
             }
             world_.sync();
             // All cores save the pointer
-            all_values_ = buffer(0);
-            other_values_ = (T**)buffer(1);
+            all_values_ = buffer.get_ref(0);
+            other_values_ = (T**)buffer.get_ref(1);
             self_value_ = other_values_[pid];
         }
     }

--- a/backends/mpi/world_provider.hpp
+++ b/backends/mpi/world_provider.hpp
@@ -223,6 +223,14 @@ class world_provider {
         MPI_Barrier(MPI_COMM_WORLD);
     }
 
+    template <typename T, class World,
+              template <typename, class> class var_type>
+    void internal_put_(int processor, T value,
+                       var_type<T, World>& the_variable) {
+        internal_put_(processor, &value, &the_variable.value(), sizeof(T), 0,
+                      1);
+    }
+
     void internal_put_(int processor, void* value, void* variable, size_t size,
                        int offset, int count) {
         /* FIXME: we really dont want to do it like this:

--- a/include/bulk/communication.hpp
+++ b/include/bulk/communication.hpp
@@ -21,11 +21,11 @@ namespace bulk {
 template <typename T, typename var_type>
 void put(int processor, T value, var_type& the_variable) {
     the_variable.world().implementation().internal_put_(
-        processor, &value, &the_variable.value(), sizeof(T), 0, 1);
+        processor, value, the_variable);
 }
 
-template <typename T, typename World>
-void put(int processor, T value, array<T, World>& the_array, int offset = 0,
+template <typename T, typename array_type>
+void put(int processor, T value, array_type& the_array, int offset,
          int count = 1) {
     the_array.world().implementation().internal_put_(
         processor, &value, the_array.data(), sizeof(T), offset, count);

--- a/include/bulk/future.hpp
+++ b/include/bulk/future.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 /**
  * \file future.hpp
  *

--- a/test/communication.cpp
+++ b/test/communication.cpp
@@ -135,6 +135,8 @@ void test_communication() {
             auto x = bulk::create_var<int>(world);
             x.value() = s;
 
+            world.sync();
+
             std::vector<bulk::future<int, decltype(world)>> ys;
             for (int i = 0; i < size; ++i) {
                 ys.push_back(bulk::get(world.next_processor(), x));


### PR DESCRIPTION
_Note:_  This depends on PR #4, which should be merged first.

Main addition is that `internal_put_` is now also provided by the cpp backend, and `var::operator()` no longer returns a reference but an image. A direct reference can be obtained using `var::get_ref`, but I do not like this because it is not bulk-synchronous. We should discuss how we want to resole this in the future.

An added problem with the current cpp variable approach is that you need to sync after creating a variable, because otherwise _getting_ a remote value is a data race. See  `test/communication.cpp:138`.
