### PR TITLE
Fix incorrect inference in `bulk::sum` and `bulk::product`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Prevent `bulk::sum` from silently truncating values.
+- Prevent `bulk::sum` and `bulk::product` from silently truncating values.
 
 ## [2.0.0] - 2020-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `bulk::index` now represents indices as `size_t`
 
+### Fixed
+
+- Prevent `bulk::sum` from silently truncating values.
+
 ## [2.0.0] - 2020-03-27
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Prevent `bulk::sum` and `bulk::product` from silently truncating values.
+- Prevent `bulk::sum` and `bulk::product` from silently truncating values (@TimoMaarse, #11)
 
 ## [2.0.0] - 2020-03-27
 

--- a/include/bulk/algorithm.hpp
+++ b/include/bulk/algorithm.hpp
@@ -190,7 +190,7 @@ T min(bulk::world& world, T t) {
 template <typename T>
 T sum(bulk::world& world, T t) {
     auto xs = bulk::gather_all(world, t);
-    return std::accumulate(xs.begin(), xs.end(), 0);
+    return std::accumulate(xs.begin(), xs.end(), T{});
 }
 
 template <typename T>

--- a/include/bulk/algorithm.hpp
+++ b/include/bulk/algorithm.hpp
@@ -196,7 +196,7 @@ T sum(bulk::world& world, T t) {
 template <typename T>
 T product(bulk::world& world, T t) {
     auto xs = bulk::gather_all(world, t);
-    return std::accumulate(xs.begin(), xs.end(), 1,
+    return std::accumulate(xs.begin(), xs.end(), (T)1,
                            [](auto& lhs, auto& rhs) { return lhs * rhs; });
 }
 

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -82,6 +82,11 @@ void test_algorithm() {
                        (std::int64_t)p *
                        (std::int64_t)std::numeric_limits<std::int32_t>::max(),
                        "sum of large values");
+            BULK_CHECK(bulk::product(world, s == 0 ?
+                                            (std::int64_t)std::numeric_limits<std::int32_t>::max() + 1 :
+                                            1) ==
+                       (std::int64_t)std::numeric_limits<std::int32_t>::max() + 1,
+                       "large product");
         }
     });
 }

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -1,5 +1,4 @@
 #include <chrono>
-#include <cstdint>
 #include <limits>
 #include <thread>
 
@@ -78,14 +77,13 @@ void test_algorithm() {
             BULK_CHECK(bulk::sum(xs) == 2 * p * (2 * p + 1) / 2,
                        "sum of coarray ");
 
-            BULK_CHECK(bulk::sum(world, (std::int64_t)std::numeric_limits<std::int32_t>::max()) ==
-                       (std::int64_t)p *
-                       (std::int64_t)std::numeric_limits<std::int32_t>::max(),
+            BULK_CHECK(bulk::sum(world, (int64_t)std::numeric_limits<int32_t>::max()) ==
+                       (int64_t)p * (int64_t)std::numeric_limits<int32_t>::max(),
                        "sum of large values");
             BULK_CHECK(bulk::product(world, s == 0 ?
-                                            (std::int64_t)std::numeric_limits<std::int32_t>::max() + 1 :
+                                            (int64_t)std::numeric_limits<int32_t>::max() + 1 :
                                             1) ==
-                       (std::int64_t)std::numeric_limits<std::int32_t>::max() + 1,
+                       (int64_t)std::numeric_limits<int32_t>::max() + 1,
                        "large product");
         }
     });

--- a/test/algorithm.cpp
+++ b/test/algorithm.cpp
@@ -1,4 +1,6 @@
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <thread>
 
 #include "bulk_test_common.hpp"
@@ -75,6 +77,11 @@ void test_algorithm() {
             BULK_CHECK(bulk::min(xs) == 1, "min of coarray");
             BULK_CHECK(bulk::sum(xs) == 2 * p * (2 * p + 1) / 2,
                        "sum of coarray ");
+
+            BULK_CHECK(bulk::sum(world, (std::int64_t)std::numeric_limits<std::int32_t>::max()) ==
+                       (std::int64_t)p *
+                       (std::int64_t)std::numeric_limits<std::int32_t>::max(),
+                       "sum of large values");
         }
     });
 }


### PR DESCRIPTION
In the overloads of `bulk::sum` and `bulk::product` taking `world` references, this PR fixes `std::accumulate` specializing to `int` regardless of the argument types and adds a few tests.

This implementation requires that `1` can be cast to `T` in `bulk::product`, which can be fixed (we can reduce without a unit element), but I noticed this is also already the case for the other `product` overload.