### PR TITLE
Fix/array move constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,18 @@ examples/bin/*
 *.pdf
 docs/doxygen/output
 docs/site
+
+### Files and folders created by using JetBrains IDE-applications. ###
+.idea
+cmake-build-*/
+out/
+
+### Files and folders created by VisualStudioCode. ###
+.vscode
+.history
+
+### Files and folders created by MacOS. ###
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
     "${TEST_DIR}/initialization.cpp"
     "${TEST_DIR}/partitioning.cpp"
     "${TEST_DIR}/test_main.cpp"
+    "${TEST_DIR}/array.cpp"
     )
 
 set(

--- a/include/bulk/array.hpp
+++ b/include/bulk/array.hpp
@@ -69,7 +69,10 @@ class array : var_base {
    * Move an array.
    */
   array(array&& other)
-      : world_(other.world_), data_(std::move(other.data_)), id_(other.id_) {
+      : world_(other.world_),
+        data_(std::move(other.data_)),
+        size_(other.size_),
+        id_(other.id_) {
     other.data_ = nullptr;
     other.id_ = -1;
   }

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -1,0 +1,24 @@
+//
+// Created by Roel Hemerik on 22/03/2022.
+//
+
+#include "bulk_test_common.hpp"
+#include "set_backend.hpp"
+
+extern environment env;
+
+void test_array() {
+  env.spawn(env.available_processors(), [](auto& world) {
+
+    BULK_SECTION("Array Move Constructor") {
+
+      auto arr = bulk::array<int>(world,20);
+
+      BULK_CHECK(arr.size() == 20, "Array size incorrectly initialised.");
+
+      auto moved_arr = bulk::array<int>(std::move(arr));
+
+      BULK_CHECK(moved_arr.size() == 20, "Array size incorrectly moved");
+    }
+  });
+}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -10,6 +10,7 @@ extern void test_initialization();
 extern void test_communication();
 extern void test_partitioning();
 extern void test_algorithm();
+extern void test_array();
 
 environment env;
 
@@ -18,6 +19,7 @@ int main() {
   test_communication();
   test_partitioning();
   test_algorithm();
+  test_array();
 
   BULK_FINALIZE_TESTS(env);
 }


### PR DESCRIPTION
I found a bug in the `array` class of the `array.hpp` file where the move-constructor did not initialize it's `size_` property. This bug also effected the `coarray`-objects when moved.

(Note: I made a mistake in the branch name. It really is the *move* constructor that is fixed, not the *copy* constructor)

### In this pull request.

This pull request has 2 commits makes following changes:

#### 9b0c9a44027e09e18bb7f1ff31ac5e46c1b5beaf

- Adds some folders to the `.gitignore` file that hides some files generated by my developing environment.

This commit is completely optional and can be omitted.

#### b4f580aaf44011e2b7108243b5aa4e9e2d8b5e9e

 - Fixes the `move-constructor` of the `array`-class to initialize the `size_` property.
 - Adds a test that would fail when the without this fix.



### My motivation to contribute.

During my UU course "Dynamic Programming" which finished last January, I noticed some bugs in Bulk which I quickly fixed during the project. Due to the deadline of that project, I wasn't able to do this in a well-documented style. I did however make some notes on these fixes.

In the coming weeks, I will post some pull-requests where I fix the bugs I encountered. I will also post some pull-requests with some extra features that I added to Bulk which might be handy for other users.
